### PR TITLE
enhancement: Allow symbol keys in nested attributes hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-No notable changes.
+### Added
+- Allow symbol keys in nested attributes hashes ([#28](https://github.com/cerbos/cerbos-sdk-ruby/pull/28))
 
 ## [0.4.0] - 2022-06-03
 ### Added

--- a/lib/cerbos/input/attributes.rb
+++ b/lib/cerbos/input/attributes.rb
@@ -22,7 +22,20 @@ module Cerbos
 
       # @private
       def to_protobuf
-        @attributes.transform_values { |value| Google::Protobuf::Value.from_ruby(value) }
+        @attributes.transform_values { |value| Google::Protobuf::Value.from_ruby(deep_stringify_keys(value)) }
+      end
+
+      private
+
+      def deep_stringify_keys(object)
+        case object
+        when Hash
+          object.each_with_object({}) { |(key, value), result| result[key.to_s] = deep_stringify_keys(value) }
+        when Array
+          object.map { |value| deep_stringify_keys(value) }
+        else
+          object
+        end
       end
     end
   end

--- a/spec/cerbos/client_spec.rb
+++ b/spec/cerbos/client_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Cerbos::Client do
             scope: "test",
             roles: ["USER"],
             attributes: {
-              country: "NZ"
+              country: {
+                alpha2: "NZ",
+                alpha3: "NZL"
+              }
             }
           },
           resource: {
@@ -53,7 +56,10 @@ RSpec.describe Cerbos::Client do
             scope: "test",
             roles: ["USER"],
             attributes: {
-              country: "NZ"
+              country: {
+                alpha2: "NZ",
+                alpha3: "NZL"
+              }
             }
           },
           resource: {
@@ -120,7 +126,10 @@ RSpec.describe Cerbos::Client do
             scope: "test",
             roles: ["USER"],
             attributes: {
-              country: "NZ"
+              country: {
+                alpha2: "NZ",
+                alpha3: "NZL"
+              }
             }
           },
           resources: [
@@ -288,7 +297,10 @@ RSpec.describe Cerbos::Client do
             scope: "test",
             roles: ["USER"],
             attributes: {
-              country: "NZ"
+              country: {
+                alpha2: "NZ",
+                alpha3: "NZL"
+              }
             }
           },
           resource: {
@@ -351,7 +363,10 @@ RSpec.describe Cerbos::Client do
               scope: "test",
               roles: ["USER"],
               attributes: {
-                country: "NZ"
+                country: {
+                  alpha2: "NZ",
+                  alpha3: "NZL"
+                }
               }
             },
             resource: {
@@ -390,7 +405,10 @@ RSpec.describe Cerbos::Client do
             scope: "test",
             roles: ["USER"],
             attributes: {
-              country: "NZ"
+              country: {
+                alpha2: "NZ",
+                alpha3: "NZL"
+              }
             }
           },
           resource: {


### PR DESCRIPTION
Currently when an attribute value is a hash, the keys must be strings. Attempting to use symbols raises ["Struct keys must be strings"](https://github.com/protocolbuffers/protobuf/blob/v3.21.1/ruby/lib/google/protobuf/well_known_types.rb#L181).

This PR deeply stringifies the hash keys in attribute values before converting them to `Google::Protobuf::Value`s.