### PR TITLE
chore(ci): Set output via environment file rather than stdout

### DIFF
--- a/bin/test-matrix
+++ b/bin/test-matrix
@@ -46,5 +46,7 @@ matrix = {
   ]
 }
 
-puts "::set-output name=matrix::#{matrix.to_json}"
 puts JSON.pretty_generate(matrix)
+
+output_file = ENV["GITHUB_OUTPUT"]
+File.write output_file, "matrix=#{matrix.to_json}" if output_file


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/