### PR TITLE
chore(test): Only publish ports on IPv6

### DIFF
--- a/spec/servers/docker-compose.yaml
+++ b/spec/servers/docker-compose.yaml
@@ -8,7 +8,9 @@ services:
     healthcheck:
       interval: 2s
     ports:
-      - 3593
+      - protocol: tcp
+        target: 3593
+        host_ip: "::1"
     user: ${USER}
     volumes:
       - type: bind
@@ -56,7 +58,9 @@ services:
         - healthcheck
         - --ping
     ports:
-      - 3593
+      - protocol: tcp
+        target: 3593
+        host_ip: "::1"
     volumes:
       - type: bind
         source: ../../tmp/certificates


### PR DESCRIPTION
As done in https://github.com/cerbos/cerbos-sdk-javascript/pull/679, we need to work around [a bug in Docker](https://github.com/moby/moby/issues/42442) where if you publish container ports to a random host port, the host port isn't guaranteed to be the same for IPv4 and IPv6, and the same port can be used for IPv4 on one container and IPv6 on another.