### PR TITLE
chore(ci): Prevent infinite loop once we hit >100 releases

### DIFF
--- a/bin/test-matrix
+++ b/bin/test-matrix
@@ -28,6 +28,8 @@ Net::HTTP.start "api.github.com", 443, use_ssl: true do |http|
       version = Gem::Version.new(release.fetch("tag_name").delete_prefix("v"))
       available_cerbos_versions << version if version >= minimum_cerbos_version
     end
+
+    page += 1
   end
 end
 


### PR DESCRIPTION
I realised when rewriting the test matrix for the JS SDK in https://github.com/cerbos/cerbos-sdk-javascript/pull/918 that the script never increments the page number when looping through the GitHub releases API 😳 