### PR TITLE
chore(ci): Require full test matrix on scheduled builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   test:
     name: Test (Cerbos ${{ matrix.cerbos }} | Ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ endsWith(matrix.cerbos, '-prerelease') }}
+    continue-on-error: ${{ github.event_name != 'schedule' && endsWith(matrix.cerbos, '-prerelease') }}
     env:
       CERBOS_VERSION: ${{ matrix.cerbos }}
     needs:


### PR DESCRIPTION
This PR makes all entries in the test matrix required for scheduled builds, so that we get a notification in Slack if the prerelease builds start failing.