### PR TITLE
chore: Drop support for Ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
   - rubocop-rspec
 
 inherit_gem:
-  standard: config/ruby-3.0.yml
+  standard: config/ruby-3.1.yml
 
 AllCops:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   This makes the API consistent with policy expressions.
   `attributes` is still supported for backwards compatibility, but is now deprecated.
 
+### Removed
+
+- Support for Ruby 3.0 ([#158](https://github.com/cerbos/cerbos-sdk-ruby/pull/158))
+
 ## [0.8.0] - 2024-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Cerbos Ruby SDK makes it easy to interact with the Cerbos PDP from your Ruby
 ## Prerequisites
 
 - Cerbos 0.16+
-- Ruby 3.0+
+- Ruby 3.1+
 
 ## Installation
 

--- a/bin/test-matrix
+++ b/bin/test-matrix
@@ -5,7 +5,7 @@ require "json"
 require "net/http"
 
 # We support non-end-of-life Ruby versions: https://www.ruby-lang.org/en/downloads/branches/
-ruby_versions = ["3.0", "3.1", "3.2", "3.3"]
+ruby_versions = ["3.1", "3.2", "3.3"]
 
 latest_ruby_version = ruby_versions.last
 

--- a/cerbos.gemspec
+++ b/cerbos.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
     "yard_extensions.rb"
   ]
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "grpc", "~> 1.46"
 end


### PR DESCRIPTION
Ruby 3.0 is [end-of-life as of 2024-04-23](https://www.ruby-lang.org/en/downloads/branches/).