### PR TITLE
chore: Drop support for Ruby 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ plugins:
   - standard-performance
 
 inherit_gem:
-  standard: config/ruby-3.1.yml
+  standard: config/ruby-3.2.yml
 
 AllCops:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Removed
+
+- Support for Ruby 3.1 ([#234](https://github.com/cerbos/cerbos-sdk-ruby/pull/234))
 
 ## [0.10.0] - 2025-02-06
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cerbos (0.10.0)
       google-protobuf (>= 3.21.12, < 5.0)
-      grpc (~> 1.46)
+      grpc (~> 1.52)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Cerbos Ruby SDK makes it easy to interact with the Cerbos PDP from your Ruby
 ## Prerequisites
 
 - Cerbos 0.16+
-- Ruby 3.1+
+- Ruby 3.2+
 
 ## Installation
 

--- a/bin/test-matrix
+++ b/bin/test-matrix
@@ -31,7 +31,7 @@ def matrix_entries(vary, *latest, include_latest: false)
 end
 
 # We support non-end-of-life Ruby versions: https://www.ruby-lang.org/en/downloads/branches/
-ruby_versions = Versions.new(["3.1", "3.2", "3.3", "3.4"])
+ruby_versions = Versions.new(["3.2", "3.3", "3.4"])
 
 minimum_cerbos_version = Gem::Version.new("0.16.0")
 available_cerbos_versions = []

--- a/cerbos.gemspec
+++ b/cerbos.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
     "yard_extensions.rb"
   ]
 
-  spec.required_ruby_version = ">= 3.1.0"
-  spec.add_dependency "grpc", "~> 1.46"
+  spec.required_ruby_version = ">= 3.2.0"
+  spec.add_dependency "grpc", "~> 1.52"
   spec.add_dependency "google-protobuf", ">= 3.21.12", "< 5.0"
 end


### PR DESCRIPTION
Ruby 3.1 is [end-of-life as of 2025-03-26](https://www.ruby-lang.org/en/downloads/branches/).