### PR TITLE
Drop support for Ruby 3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ plugins:
   - standard-performance
 
 inherit_gem:
-  standard: config/ruby-3.2.yml
+  standard: config/ruby-3.3.yml
 
 AllCops:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Removed
+
+- Support for Ruby 3.2 ([#310](https://github.com/cerbos/cerbos-sdk-ruby/pull/310))
 
 ## [0.13.0] - 2026-02-18
 

--- a/bin/test-matrix
+++ b/bin/test-matrix
@@ -24,7 +24,7 @@ def resolve_dependency_versions(dependency)
 end
 
 # We support non-end-of-life Ruby versions: https://www.ruby-lang.org/en/downloads/branches/
-ruby_versions = Versions.new(["3.2", "3.3", "3.4", "4.0"])
+ruby_versions = Versions.new(["3.3", "3.4", "4.0"])
 
 minimum_cerbos_version = Gem::Version.new("0.16.0")
 available_cerbos_versions = []

--- a/cerbos.gemspec
+++ b/cerbos.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
     "yard_extensions.rb"
   ]
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
   spec.add_dependency "grpc", "~> 1.52"
   spec.add_dependency "google-protobuf", ">= 3.21.12", "< 5.0"


### PR DESCRIPTION
Ruby 3.2 is [EOL as of 2026-04-01](https://www.ruby-lang.org/en/downloads/branches/#ruby-32).