### PR TITLE
Require `google-protobuf` 3.25+ and `grpc` 1.61+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Changed
+
+- Require [`google-protobuf`] 3.25+ ([#314](https://github.com/cerbos/cerbos-sdk-ruby/pull/314))
+- Require [`grpc`] 1.61+ ([#314](https://github.com/cerbos/cerbos-sdk-ruby/pull/314))
+
 ### Removed
 
 - Support for Ruby 3.2 ([#310](https://github.com/cerbos/cerbos-sdk-ruby/pull/310))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     cerbos (0.13.0)
       concurrent-ruby (~> 1.2)
-      google-protobuf (>= 3.21.12, < 5.0)
-      grpc (~> 1.52)
+      google-protobuf (>= 3.25, < 5.0)
+      grpc (~> 1.61)
 
 GEM
   remote: https://rubygems.org/

--- a/cerbos.gemspec
+++ b/cerbos.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.3"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
-  spec.add_dependency "grpc", "~> 1.52"
-  spec.add_dependency "google-protobuf", ">= 3.21.12", "< 5.0"
+  spec.add_dependency "grpc", "~> 1.61"
+  spec.add_dependency "google-protobuf", ">= 3.25", "< 5.0"
 end


### PR DESCRIPTION
Older versions of these gems don't ship with precompiled binaries for modern Ruby versions, so they have to be compiled from source making them painfully slow to install.