### PR TITLE
Fix link checking

### DIFF
--- a/bin/check-links
+++ b/bin/check-links
@@ -13,14 +13,6 @@ exec docker compose \
   --interactive \
   --rm \
   lychee \
+  --config /input/lychee.toml \
   "${excludes[@]}" \
-  --exclude-path vendor/bundle \
-  --format detailed \
-  --include-fragments \
-  --max-concurrency 8 \
-  --no-ignore \
-  --remap "^https://cerbos\.github\.io/cerbos-sdk-ruby$ file:///input/doc/index.html" \
-  --remap "^https://cerbos\.github\.io/cerbos-sdk-ruby/ file:///input/doc/" \
-  --root-dir /input \
-  --verbose \
   .

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,22 @@
+format = "detailed"
+verbose = "debug"
+
+max_concurrency = 8
+
+include_fragments = true
+no_ignore = true
+
+exclude_path = [
+  "vendor/bundle",
+]
+
+remap = [
+  '^https://cerbos\.github\.io/cerbos-sdk-ruby$ file:///input/doc/index.html',
+  '^https://cerbos\.github\.io/cerbos-sdk-ruby/ file:///input/doc/',
+]
+
+root_dir = "/input"
+
+# Slack returns 403 to unsupported browsers
+[hosts."go.cerbos.io".headers]
+"User-Agent" = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"


### PR DESCRIPTION
Slack has started returning 403 to unsupported browsers, which means that link checking fails after redirecting from https://go.cerbos.io/slack.

This PR overrides the user agent when checking that link to spoof a real browser.