### PR TITLE
Attempt to fix flaky test

### DIFF
--- a/spec/cerbos/client_spec.rb
+++ b/spec/cerbos/client_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "stub_server"
-
 RSpec.describe Cerbos::Client do
   subject(:client) { described_class.new(target, grpc_metadata:, on_validation_error:, tls:) }
 

--- a/spec/cerbos/stub_server.rb
+++ b/spec/cerbos/stub_server.rb
@@ -10,7 +10,7 @@ class StubServer
   end
 
   def start
-    @server = GRPC::RpcServer.new(pool_size: 1)
+    @server = GRPC::RpcServer.new
     @port = @server.add_http2_port("localhost:0", :this_port_is_insecure)
     @server.handle @cerbos_service
     @server.handle @api_key_service

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ require "jwt"
 require "uri"
 require "zip"
 
+require_relative "cerbos/stub_server"
+
 RSpec.configure do |config|
   config.default_formatter = "doc" if config.files_to_run.one?
   config.disable_monkey_patching!


### PR DESCRIPTION
Occasionally tests fail with

```
Cerbos::Error::ResourceExhausted: gRPC error 8: No free threads in thread pool
```

It seems to come from the stub server, which is currently configured with a pool size of 1. In theory it shouldn't be handling multiple concurrent requests so this should be sufficient, but I wonder if it's not releasing the connection quickly enough for the next request to come in 🤷‍♂️ 

This PR removes the configured pool size so that it can use the default of 30.